### PR TITLE
indentation with go fmt

### DIFF
--- a/post-processor.go
+++ b/post-processor.go
@@ -1,233 +1,233 @@
 package main
 
 import (
-  "compress/flate"
-  "fmt"
-  "io/ioutil"
-  "os"
-  "path/filepath"
-  "text/template"
+	"compress/flate"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
 
-  "github.com/mitchellh/packer/common"
-  "github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
 )
 
 var builtins = map[string]string{
-  "mitchellh.vmware":          "vmware",
+	"mitchellh.vmware": "vmware",
 }
 
 type Config struct {
-  common.PackerConfig `mapstructure:",squash"`
+	common.PackerConfig `mapstructure:",squash"`
 
-  CompressionLevel    int      `mapstructure:"compression_level"`
-  Include             []string `mapstructure:"include"`
-  OutputPath          string   `mapstructure:"output"`
-  Override            map[string]interface{}
-  VagrantfileTemplate string `mapstructure:"vagrantfile_template"`
-  Provider            string `mapstructure:"provider"`
+	CompressionLevel    int      `mapstructure:"compression_level"`
+	Include             []string `mapstructure:"include"`
+	OutputPath          string   `mapstructure:"output"`
+	Override            map[string]interface{}
+	VagrantfileTemplate string `mapstructure:"vagrantfile_template"`
+	Provider            string `mapstructure:"provider"`
 
-  tpl *packer.ConfigTemplate
+	tpl *packer.ConfigTemplate
 }
 
 type PostProcessor struct {
-  configs map[string]*Config
+	configs map[string]*Config
 }
 
 func (p *PostProcessor) Configure(raws ...interface{}) error {
-  p.configs = make(map[string]*Config)
-  p.configs[""] = new(Config)
-  if err := p.configureSingle(p.configs[""], raws...); err != nil {
-    return err
-  }
+	p.configs = make(map[string]*Config)
+	p.configs[""] = new(Config)
+	if err := p.configureSingle(p.configs[""], raws...); err != nil {
+		return err
+	}
 
-  // Go over any of the provider-specific overrides and load those up.
-  for name, override := range p.configs[""].Override {
-    subRaws := make([]interface{}, len(raws)+1)
-    copy(subRaws, raws)
-    subRaws[len(raws)] = override
+	// Go over any of the provider-specific overrides and load those up.
+	for name, override := range p.configs[""].Override {
+		subRaws := make([]interface{}, len(raws)+1)
+		copy(subRaws, raws)
+		subRaws[len(raws)] = override
 
-    config := new(Config)
-    p.configs[name] = config
-    if err := p.configureSingle(config, subRaws...); err != nil {
-      return fmt.Errorf("Error configuring %s: %s", name, err)
-    }
-  }
+		config := new(Config)
+		p.configs[name] = config
+		if err := p.configureSingle(config, subRaws...); err != nil {
+			return fmt.Errorf("Error configuring %s: %s", name, err)
+		}
+	}
 
-  return nil
+	return nil
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-  name, ok := builtins[artifact.BuilderId()]
-  if !ok {
-    return nil, false, fmt.Errorf(
-      "Unknown artifact type, can't build box: %s", artifact.BuilderId())
-  }
+	name, ok := builtins[artifact.BuilderId()]
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"Unknown artifact type, can't build box: %s", artifact.BuilderId())
+	}
 
-  provider := providerForName(name)
+	provider := providerForName(name)
 
-  config := p.configs[""]
-  if specificConfig, ok := p.configs[name]; ok {
-    config = specificConfig
-  }
+	config := p.configs[""]
+	if specificConfig, ok := p.configs[name]; ok {
+		config = specificConfig
+	}
 
-   // Optional provider config to set eg. vcloud
-  if config.Provider != "" {
-    name = config.Provider
-    provider = providerForName(name)
-    if provider == nil {
-      panic(fmt.Sprintf("bad provider name: %s", name))
-    }
-  }
+	// Optional provider config to set eg. vcloud
+	if config.Provider != "" {
+		name = config.Provider
+		provider = providerForName(name)
+		if provider == nil {
+			panic(fmt.Sprintf("bad provider name: %s", name))
+		}
+	}
 
-  ui.Say(fmt.Sprintf("Creating Vagrant box for '%s' provider", name))
+	ui.Say(fmt.Sprintf("Creating Vagrant box for '%s' provider", name))
 
-  outputPath, err := config.tpl.Process(config.OutputPath, &outputPathTemplate{
-    ArtifactId: artifact.Id(),
-    BuildName:  config.PackerBuildName,
-    Provider:   name,
-  })
-  if err != nil {
-    return nil, false, err
-  }
+	outputPath, err := config.tpl.Process(config.OutputPath, &outputPathTemplate{
+		ArtifactId: artifact.Id(),
+		BuildName:  config.PackerBuildName,
+		Provider:   name,
+	})
+	if err != nil {
+		return nil, false, err
+	}
 
-  // Create a temporary directory for us to build the contents of the box in
-  dir, err := ioutil.TempDir("", "packer")
-  if err != nil {
-    return nil, false, err
-  }
-  defer os.RemoveAll(dir)
+	// Create a temporary directory for us to build the contents of the box in
+	dir, err := ioutil.TempDir("", "packer")
+	if err != nil {
+		return nil, false, err
+	}
+	defer os.RemoveAll(dir)
 
-  // Copy all of the includes files into the temporary directory
-  for _, src := range config.Include {
-    ui.Message(fmt.Sprintf("Copying from include: %s", src))
-    dst := filepath.Join(dir, filepath.Base(src))
-    if err := CopyContents(dst, src); err != nil {
-      err = fmt.Errorf("Error copying include file: %s\n\n%s", src, err)
-      return nil, false, err
-    }
-  }
+	// Copy all of the includes files into the temporary directory
+	for _, src := range config.Include {
+		ui.Message(fmt.Sprintf("Copying from include: %s", src))
+		dst := filepath.Join(dir, filepath.Base(src))
+		if err := CopyContents(dst, src); err != nil {
+			err = fmt.Errorf("Error copying include file: %s\n\n%s", src, err)
+			return nil, false, err
+		}
+	}
 
-  // Run the provider processing step
-  vagrantfile, metadata, err := provider.Process(ui, artifact, dir)
-  if err != nil {
-    return nil, false, err
-  }
+	// Run the provider processing step
+	vagrantfile, metadata, err := provider.Process(ui, artifact, dir)
+	if err != nil {
+		return nil, false, err
+	}
 
-  // Write the metadata we got
-  if err := WriteMetadata(dir, metadata); err != nil {
-    return nil, false, err
-  }
+	// Write the metadata we got
+	if err := WriteMetadata(dir, metadata); err != nil {
+		return nil, false, err
+	}
 
-  // Write our Vagrantfile
-  var customVagrantfile string
-  if config.VagrantfileTemplate != "" {
-    ui.Message(fmt.Sprintf(
-      "Using custom Vagrantfile: %s", config.VagrantfileTemplate))
-    customBytes, err := ioutil.ReadFile(config.VagrantfileTemplate)
-    if err != nil {
-      return nil, false, err
-    }
+	// Write our Vagrantfile
+	var customVagrantfile string
+	if config.VagrantfileTemplate != "" {
+		ui.Message(fmt.Sprintf(
+			"Using custom Vagrantfile: %s", config.VagrantfileTemplate))
+		customBytes, err := ioutil.ReadFile(config.VagrantfileTemplate)
+		if err != nil {
+			return nil, false, err
+		}
 
-    customVagrantfile = string(customBytes)
-  }
+		customVagrantfile = string(customBytes)
+	}
 
-  f, err := os.Create(filepath.Join(dir, "Vagrantfile"))
-  if err != nil {
-    return nil, false, err
-  }
+	f, err := os.Create(filepath.Join(dir, "Vagrantfile"))
+	if err != nil {
+		return nil, false, err
+	}
 
-  t := template.Must(template.New("root").Parse(boxVagrantfileContents))
-  err = t.Execute(f, &vagrantfileTemplate{
-    ProviderVagrantfile: vagrantfile,
-    CustomVagrantfile:   customVagrantfile,
-  })
-  f.Close()
-  if err != nil {
-    return nil, false, err
-  }
+	t := template.Must(template.New("root").Parse(boxVagrantfileContents))
+	err = t.Execute(f, &vagrantfileTemplate{
+		ProviderVagrantfile: vagrantfile,
+		CustomVagrantfile:   customVagrantfile,
+	})
+	f.Close()
+	if err != nil {
+		return nil, false, err
+	}
 
-  // Create the box
-  if err := DirToBox(outputPath, dir, ui, config.CompressionLevel); err != nil {
-    return nil, false, err
-  }
+	// Create the box
+	if err := DirToBox(outputPath, dir, ui, config.CompressionLevel); err != nil {
+		return nil, false, err
+	}
 
-  return NewArtifact(name, outputPath), provider.KeepInputArtifact(), nil
+	return NewArtifact(name, outputPath), provider.KeepInputArtifact(), nil
 }
 
 func (p *PostProcessor) configureSingle(config *Config, raws ...interface{}) error {
-  md, err := common.DecodeConfig(config, raws...)
-  if err != nil {
-    return err
-  }
+	md, err := common.DecodeConfig(config, raws...)
+	if err != nil {
+		return err
+	}
 
-  config.tpl, err = packer.NewConfigTemplate()
-  if err != nil {
-    return err
-  }
-  config.tpl.UserVars = config.PackerUserVars
+	config.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return err
+	}
+	config.tpl.UserVars = config.PackerUserVars
 
-  // Defaults
-  if config.OutputPath == "" {
-    config.OutputPath = "packer_{{ .BuildName }}_{{.Provider}}.box"
-  }
+	// Defaults
+	if config.OutputPath == "" {
+		config.OutputPath = "packer_{{ .BuildName }}_{{.Provider}}.box"
+	}
 
-  found := false
-  for _, k := range md.Keys {
-    if k == "compression_level" {
-      found = true
-      break
-    }
-  }
+	found := false
+	for _, k := range md.Keys {
+		if k == "compression_level" {
+			found = true
+			break
+		}
+	}
 
-  if !found {
-    config.CompressionLevel = flate.DefaultCompression
-  }
+	if !found {
+		config.CompressionLevel = flate.DefaultCompression
+	}
 
-  // Accumulate any errors
-  errs := common.CheckUnusedConfig(md)
+	// Accumulate any errors
+	errs := common.CheckUnusedConfig(md)
 
-  validates := map[string]*string{
-    "output":               &config.OutputPath,
-    "vagrantfile_template": &config.VagrantfileTemplate,
-    "provider":             &config.Provider,
-  }
+	validates := map[string]*string{
+		"output":               &config.OutputPath,
+		"vagrantfile_template": &config.VagrantfileTemplate,
+		"provider":             &config.Provider,
+	}
 
-  for n, ptr := range validates {
-    if err := config.tpl.Validate(*ptr); err != nil {
-      errs = packer.MultiErrorAppend(
-        errs, fmt.Errorf("Error parsing %s: %s", n, err))
-    }
-  }
+	for n, ptr := range validates {
+		if err := config.tpl.Validate(*ptr); err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error parsing %s: %s", n, err))
+		}
+	}
 
-  if errs != nil && len(errs.Errors) > 0 {
-    return errs
-  }
+	if errs != nil && len(errs.Errors) > 0 {
+		return errs
+	}
 
-  return nil
+	return nil
 }
 
 func providerForName(name string) Provider {
-  switch name {
-  case "vcloud":
-    return new(VMwarevCloudProvider)
-  case "vcenter":
-    return new(VMwarevCenterProvider)
-  default:
-    return nil
-  }
+	switch name {
+	case "vcloud":
+		return new(VMwarevCloudProvider)
+	case "vcenter":
+		return new(VMwarevCenterProvider)
+	default:
+		return nil
+	}
 }
 
 // OutputPathTemplate is the structure that is availalable within the
 // OutputPath variables.
 type outputPathTemplate struct {
-  ArtifactId string
-  BuildName  string
-  Provider   string
+	ArtifactId string
+	BuildName  string
+	Provider   string
 }
 
 type vagrantfileTemplate struct {
-  ProviderVagrantfile string
-  CustomVagrantfile   string
+	ProviderVagrantfile string
+	CustomVagrantfile   string
 }
 
 const boxVagrantfileContents string = `

--- a/vmware-vcenter.go
+++ b/vmware-vcenter.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"github.com/mitchellh/packer/packer"
+	"io/ioutil"
+	"os"
+	"os/exec"
 	"path/filepath"
-  "os"
-  "os/exec"
-  "io/ioutil"
-  "strings"
+	"strings"
 )
 
 type VMwarevCenterProvider struct{}
@@ -20,34 +20,34 @@ func (p *VMwarevCenterProvider) Process(ui packer.Ui, artifact packer.Artifact, 
 	// Create the metadata
 	metadata = map[string]interface{}{"provider": "vcenter"}
 
-  vmx := ""
-  ovf := ""
-  basepath := ""
-  for _, path := range artifact.Files() {
-    if strings.HasSuffix(path, ".vmx") {
-      vmx = path
-      ovf = filepath.Base(vmx[:len(vmx)-4] + ".ovf")
-      basepath = filepath.Dir(path) + "/ovf"
-    }
-  }
-    
-  // start upload
-  ui.Message(fmt.Sprintf("ovftool is going create an ovf out of %s", vmx))
-  
-  program := "ovftool"
-  sourcetype := "--sourceType=VMX"
-  targettype := "--targetType=OVF"
+	vmx := ""
+	ovf := ""
+	basepath := ""
+	for _, path := range artifact.Files() {
+		if strings.HasSuffix(path, ".vmx") {
+			vmx = path
+			ovf = filepath.Base(vmx[:len(vmx)-4] + ".ovf")
+			basepath = filepath.Dir(path) + "/ovf"
+		}
+	}
 
-  // start upload
-  ui.Message(fmt.Sprintf("this is our ovftool run %s %s %s %s %s", program, sourcetype, targettype, vmx, basepath + "/" + ovf))
+	// start upload
+	ui.Message(fmt.Sprintf("ovftool is going create an ovf out of %s", vmx))
 
-  ui.Message(fmt.Sprintf("Creating directory: %s", basepath))
+	program := "ovftool"
+	sourcetype := "--sourceType=VMX"
+	targettype := "--targetType=OVF"
 
-  if err := os.Mkdir(basepath, 0755); err != nil { 
-    ui.Message(fmt.Sprintf("err: %s", err))
-  } 
+	// start upload
+	ui.Message(fmt.Sprintf("this is our ovftool run %s %s %s %s %s", program, sourcetype, targettype, vmx, basepath+"/"+ovf))
 
-  cmd := exec.Command(program, sourcetype, targettype, vmx, basepath + "/" + ovf)
+	ui.Message(fmt.Sprintf("Creating directory: %s", basepath))
+
+	if err := os.Mkdir(basepath, 0755); err != nil {
+		ui.Message(fmt.Sprintf("err: %s", err))
+	}
+
+	cmd := exec.Command(program, sourcetype, targettype, vmx, basepath+"/"+ovf)
 
 	ui.Message(fmt.Sprintf("Starting ovftool"))
 
@@ -55,18 +55,17 @@ func (p *VMwarevCenterProvider) Process(ui packer.Ui, artifact packer.Artifact, 
 	cmd.Wait()
 
 	ui.Message(fmt.Sprintf("Reading files in %s", basepath))
-  files, _ := ioutil.ReadDir(basepath)
-  for _, path := range files {
-  //         ui.Message(fmt.Sprintf("%s", f.Name()))
-  // }
+	files, _ := ioutil.ReadDir(basepath)
+	for _, path := range files {
+		//         ui.Message(fmt.Sprintf("%s", f.Name()))
+		// }
 
-
-	// Copy all of the original contents into the temporary directory
-	// for _, path := range artifact.Files() {
+		// Copy all of the original contents into the temporary directory
+		// for _, path := range artifact.Files() {
 		ui.Message(fmt.Sprintf("Copying: %s", path.Name()))
 
 		dstPath := filepath.Join(dir, path.Name())
-		if err = CopyContents(dstPath, basepath + "/" + path.Name()); err != nil {
+		if err = CopyContents(dstPath, basepath+"/"+path.Name()); err != nil {
 			return
 		}
 	}

--- a/vmware-vcloud.go
+++ b/vmware-vcloud.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"github.com/mitchellh/packer/packer"
+	"io/ioutil"
+	"os"
+	"os/exec"
 	"path/filepath"
-  "os"
-  "os/exec"
-  "io/ioutil"
-  "strings"
+	"strings"
 )
 
 type VMwarevCloudProvider struct{}
@@ -20,34 +20,34 @@ func (p *VMwarevCloudProvider) Process(ui packer.Ui, artifact packer.Artifact, d
 	// Create the metadata
 	metadata = map[string]interface{}{"provider": "vcloud"}
 
-  vmx := ""
-  ovf := ""
-  basepath := ""
-  for _, path := range artifact.Files() {
-    if strings.HasSuffix(path, ".vmx") {
-      vmx = path
-      ovf = filepath.Base(vmx[:len(vmx)-4] + ".ovf")
-      basepath = filepath.Dir(path) + "/ovf"
-    }
-  }
-    
-  // start upload
-  ui.Message(fmt.Sprintf("ovftool is going create an ovf out of %s", vmx))
-  
-  program := "ovftool"
-  sourcetype := "--sourceType=VMX"
-  targettype := "--targetType=OVF"
+	vmx := ""
+	ovf := ""
+	basepath := ""
+	for _, path := range artifact.Files() {
+		if strings.HasSuffix(path, ".vmx") {
+			vmx = path
+			ovf = filepath.Base(vmx[:len(vmx)-4] + ".ovf")
+			basepath = filepath.Dir(path) + "/ovf"
+		}
+	}
 
-  // start upload
-  ui.Message(fmt.Sprintf("this is our ovftool run %s %s %s %s %s", program, sourcetype, targettype, vmx, basepath + "/" + ovf))
+	// start upload
+	ui.Message(fmt.Sprintf("ovftool is going create an ovf out of %s", vmx))
 
-  ui.Message(fmt.Sprintf("Creating directory: %s", basepath))
+	program := "ovftool"
+	sourcetype := "--sourceType=VMX"
+	targettype := "--targetType=OVF"
 
-  if err := os.Mkdir(basepath, 0755); err != nil { 
-    ui.Message(fmt.Sprintf("err: %s", err))
-  } 
+	// start upload
+	ui.Message(fmt.Sprintf("this is our ovftool run %s %s %s %s %s", program, sourcetype, targettype, vmx, basepath+"/"+ovf))
 
-  cmd := exec.Command(program, sourcetype, targettype, vmx, basepath + "/" + ovf)
+	ui.Message(fmt.Sprintf("Creating directory: %s", basepath))
+
+	if err := os.Mkdir(basepath, 0755); err != nil {
+		ui.Message(fmt.Sprintf("err: %s", err))
+	}
+
+	cmd := exec.Command(program, sourcetype, targettype, vmx, basepath+"/"+ovf)
 
 	ui.Message(fmt.Sprintf("Starting ovftool"))
 
@@ -55,18 +55,17 @@ func (p *VMwarevCloudProvider) Process(ui packer.Ui, artifact packer.Artifact, d
 	cmd.Wait()
 
 	ui.Message(fmt.Sprintf("Reading files in %s", basepath))
-  files, _ := ioutil.ReadDir(basepath)
-  for _, path := range files {
-  //         ui.Message(fmt.Sprintf("%s", f.Name()))
-  // }
+	files, _ := ioutil.ReadDir(basepath)
+	for _, path := range files {
+		//         ui.Message(fmt.Sprintf("%s", f.Name()))
+		// }
 
-
-	// Copy all of the original contents into the temporary directory
-	// for _, path := range artifact.Files() {
+		// Copy all of the original contents into the temporary directory
+		// for _, path := range artifact.Files() {
 		ui.Message(fmt.Sprintf("Copying: %s", path.Name()))
 
 		dstPath := filepath.Join(dir, path.Name())
-		if err = CopyContents(dstPath, basepath + "/" + path.Name()); err != nil {
+		if err = CopyContents(dstPath, basepath+"/"+path.Name()); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Thanks for releasing the packer post-processor!
One of the first things I have learned in Go is to use the builtin indentation (although it might look different to other languages using tabs instead of spaces).

So, what I did in this PR is just a

```
go fmt
```

to the source tree. I currently use Sublime with GoSublime plugin which also just does a `go fmt` when saving a go source file.

Further reading on [stackoverflow](http://stackoverflow.com/questions/19094704/indentation-in-go-tabs-or-spaces), there are links to the official indentation guide which also has some tips for vim and other editors.
